### PR TITLE
Add Clear Filters button to reset tag filter, search input, and sort order

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -16,33 +16,36 @@ function App() {
   const [sortBy, setSortBy] = useState('createdAt');
   const [sortOrder, setSortOrder] = useState('desc');
 
+  // Check if any filters are applied
+  const areFiltersApplied = searchTerm !== '' || selectedTags.length > 0 || sortBy !== 'createdAt' || sortOrder !== 'desc';
+
   // Fetch links based on filters
   const fetchLinks = async () => {
     setIsLoading(true);
     setError(null);
-    
+
     try {
       let url = `${API_URL}/links?sortBy=${sortBy}&sortOrder=${sortOrder}`;
-      
+
       if (searchTerm) {
         url += `&search=${encodeURIComponent(searchTerm)}`;
       }
-      
+
       if (selectedTags.length > 0) {
         // For simplicity, we're just using the first selected tag for filtering
         // A more complex implementation would handle multiple tags
         url += `&tag=${encodeURIComponent(selectedTags[0])}`;
       }
-      
+
       const response = await fetch(url);
-      
+
       if (!response.ok) {
         throw new Error('Failed to fetch links');
       }
-      
+
       const data = await response.json();
       setLinks(data);
-      
+
       // Extract all unique tags
       const tags = new Set();
       data.forEach(link => {
@@ -50,7 +53,7 @@ function App() {
           link.tags.forEach(tag => tags.add(tag));
         }
       });
-      
+
       setAllTags(Array.from(tags));
     } catch (err) {
       setError(err.message);
@@ -74,11 +77,11 @@ function App() {
         },
         body: JSON.stringify(linkData),
       });
-      
+
       if (!response.ok) {
         throw new Error('Failed to add link');
       }
-      
+
       setIsAddModalOpen(false);
       fetchLinks();
     } catch (err) {
@@ -92,11 +95,11 @@ function App() {
       const response = await fetch(`${API_URL}/links/${id}`, {
         method: 'DELETE',
       });
-      
+
       if (!response.ok) {
         throw new Error('Failed to delete link');
       }
-      
+
       fetchLinks();
     } catch (err) {
       setError(err.message);
@@ -113,15 +116,23 @@ function App() {
         },
         body: JSON.stringify(data),
       });
-      
+
       if (!response.ok) {
         throw new Error('Failed to update link');
       }
-      
+
       fetchLinks();
     } catch (err) {
       setError(err.message);
     }
+  };
+
+  // Clear all filters and reset to default values
+  const handleClearFilters = () => {
+    setSearchTerm('');
+    setSelectedTags([]);
+    setSortBy('createdAt');
+    setSortOrder('desc');
   };
 
   return (
@@ -137,21 +148,21 @@ function App() {
           </button>
         </div>
       </header>
-      
+
       <main className="max-w-7xl mx-auto py-6 sm:px-6 lg:px-8">
         <div className="px-4 py-6 sm:px-0">
           <div className="mb-6 flex flex-col md:flex-row gap-4">
             <div className="flex-1">
-              <SearchBar 
-                searchTerm={searchTerm} 
-                setSearchTerm={setSearchTerm} 
+              <SearchBar
+                searchTerm={searchTerm}
+                setSearchTerm={setSearchTerm}
               />
             </div>
             <div className="md:w-1/3">
-              <TagFilter 
-                allTags={allTags} 
-                selectedTags={selectedTags} 
-                setSelectedTags={setSelectedTags} 
+              <TagFilter
+                allTags={allTags}
+                selectedTags={selectedTags}
+                setSelectedTags={setSelectedTags}
               />
             </div>
             <div className="md:w-1/4">
@@ -170,33 +181,43 @@ function App() {
                 <option value="title-desc">Title (Z-A)</option>
               </select>
             </div>
+            <div className="md:w-auto flex items-center">
+              <button
+                onClick={handleClearFilters}
+                disabled={!areFiltersApplied}
+                className="ml-2 px-3 py-2 text-sm border border-gray-300 rounded-md text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-gray-500 disabled:opacity-50 disabled:cursor-not-allowed"
+                aria-label="Clear all filters"
+              >
+                Clear Filters
+              </button>
+            </div>
           </div>
-          
+
           {error && (
             <div className="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded mb-4">
               {error}
             </div>
           )}
-          
+
           {isLoading ? (
             <div className="flex justify-center py-8">
               <div className="animate-spin rounded-full h-12 w-12 border-t-2 border-b-2 border-blue-500"></div>
             </div>
           ) : (
-            <LinkList 
-              links={links} 
-              onDelete={handleDeleteLink} 
+            <LinkList
+              links={links}
+              onDelete={handleDeleteLink}
               onUpdate={handleUpdateLink}
               allTags={allTags}
             />
           )}
         </div>
       </main>
-      
+
       {isAddModalOpen && (
-        <AddLinkForm 
-          onAdd={handleAddLink} 
-          onClose={() => setIsAddModalOpen(false)} 
+        <AddLinkForm
+          onAdd={handleAddLink}
+          onClose={() => setIsAddModalOpen(false)}
           existingTags={allTags}
         />
       )}

--- a/frontend/src/__tests__/App.test.js
+++ b/frontend/src/__tests__/App.test.js
@@ -1,0 +1,128 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import App from '../App';
+
+// Mock the fetch function
+global.fetch = jest.fn();
+
+describe('Clear Filters Button', () => {
+  beforeEach(() => {
+    // Mock successful API response
+    global.fetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ([
+        {
+          id: '1',
+          url: 'https://example.com',
+          title: 'Example Link',
+          tags: ['tag1', 'tag2'],
+          createdAt: '2023-01-01T00:00:00.000Z'
+        }
+      ])
+    });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('Clear Filters button should be disabled when no filters are applied', async () => {
+    render(<App />);
+
+    // Wait for the initial data to load
+    await waitFor(() => expect(global.fetch).toHaveBeenCalledTimes(1));
+
+    // Find the Clear Filters button
+    const clearFiltersButton = screen.getByText('Clear Filters');
+
+    // Button should be disabled initially
+    expect(clearFiltersButton).toBeDisabled();
+  });
+
+  test('Clear Filters button should be enabled when search filter is applied', async () => {
+    render(<App />);
+
+    // Wait for the initial data to load
+    await waitFor(() => expect(global.fetch).toHaveBeenCalledTimes(1));
+
+    // Apply search filter
+    const searchInput = screen.getByPlaceholderText(/Search links/i);
+    fireEvent.change(searchInput, { target: { value: 'test search' } });
+
+    // Mock the fetch call for the search
+    global.fetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ([])
+    });
+
+    // Wait for the search API call
+    await waitFor(() => expect(global.fetch).toHaveBeenCalledTimes(2));
+
+    // Find the Clear Filters button
+    const clearFiltersButton = screen.getByText('Clear Filters');
+
+    // Button should be enabled
+    expect(clearFiltersButton).not.toBeDisabled();
+  });
+
+  test('Clear Filters button should reset all filters when clicked', async () => {
+    render(<App />);
+
+    // Wait for the initial data to load
+    await waitFor(() => expect(global.fetch).toHaveBeenCalledTimes(1));
+
+    // Apply search filter
+    const searchInput = screen.getByPlaceholderText(/Search links/i);
+    fireEvent.change(searchInput, { target: { value: 'test search' } });
+
+    // Mock the fetch call for the search
+    global.fetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ([])
+    });
+
+    // Wait for the search API call
+    await waitFor(() => expect(global.fetch).toHaveBeenCalledTimes(2));
+
+    // Change sort order
+    const sortDropdown = screen.getByRole('combobox');
+    fireEvent.change(sortDropdown, { target: { value: 'title-asc' } });
+
+    // Mock the fetch call for the sort change
+    global.fetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ([])
+    });
+
+    // Wait for the sort API call
+    await waitFor(() => expect(global.fetch).toHaveBeenCalledTimes(3));
+
+    // Find the Clear Filters button
+    const clearFiltersButton = screen.getByText('Clear Filters');
+
+    // Button should be enabled
+    expect(clearFiltersButton).not.toBeDisabled();
+
+    // Click the Clear Filters button
+    fireEvent.click(clearFiltersButton);
+
+    // Mock the fetch call after clearing filters
+    global.fetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ([])
+    });
+
+    // Wait for the API call after clearing filters
+    await waitFor(() => expect(global.fetch).toHaveBeenCalledTimes(4));
+
+    // Search input should be empty
+    expect(searchInput.value).toBe('');
+
+    // Sort dropdown should be reset to default
+    expect(sortDropdown.value).toBe('createdAt-desc');
+
+    // Button should be disabled again
+    expect(clearFiltersButton).toBeDisabled();
+  });
+});

--- a/frontend/src/setupTests.js
+++ b/frontend/src/setupTests.js
@@ -1,0 +1,5 @@
+// jest-dom adds custom jest matchers for asserting on DOM nodes.
+// allows you to do things like:
+// expect(element).toHaveTextContent(/react/i)
+// learn more: https://github.com/testing-library/jest-dom
+import '@testing-library/jest-dom';

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -7,13 +7,4 @@ module.exports = {
     extend: {},
   },
   plugins: [],
-}/** @type {import('tailwindcss').Config} */
-module.exports = {
-  content: [
-    "./src/**/*.{js,jsx,ts,tsx}",
-  ],
-  theme: {
-    extend: {},
-  },
-  plugins: [],
 }


### PR DESCRIPTION
## Description
This PR implements Issue #1 by adding a Clear Filters button that resets all filtering options with a single click.

## Changes
- Added a Clear Filters button next to the sort dropdown
- Implemented functionality to reset search input, tag selection, and sort order
- Added conditional rendering to disable the button when no filters are applied
- Added keyboard accessibility (focusable via Tab, triggered with Enter)
- Created tests to verify the button's functionality
- Fixed duplicate content in tailwind.config.js

## Testing
Added unit tests that verify:
- Button is disabled when no filters are applied
- Button is enabled when filters are applied
- Button correctly resets all filters when clicked

## Screenshots
(Please add screenshots of the feature in action)

Closes #1

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author